### PR TITLE
Migrate from pytube3 to pytubefix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,32 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+Single-script Python project that downloads a YouTube video and generates a PNG "barcode" image where each vertical line is the average colour of one frame per second of video.
+
+## Commands
+
+Install dependencies (no requirements.txt exists):
+```
+pip install pytubefix opencv-python pillow
+```
+
+Run the script (prompts interactively for a YouTube URL):
+```
+python average-colours.py
+```
+
+There is no test framework, linter, or build step. `test/test.py` is a standalone PIL scratch script, not an automated test — run it directly with `python test/test.py` to see a sample gradient image.
+
+## Architecture
+
+Everything lives in `average-colours.py`. The pipeline in `average_colours(video_url)`:
+
+1. Deletes and recreates the `cache/` working directory (gitignored).
+2. Downloads the video via pytubefix as `cache/test.mp4` (360p mp4 stream).
+3. `get_colour_list()` uses OpenCV to extract one frame per second (based on FPS) into `cache/frames/`, and `get_average_colour()` computes each frame's mean RGB via `PIL.ImageStat`.
+4. Draws one vertical line per frame colour, resizes to 1920x1080, saves as `output.png` in the repo root, and opens it in the default viewer.
+
+Note: the project originally used `pytube`/`pytube3`, but those are unmaintained and fail against current YouTube (HTTP 410). It now uses `pytubefix`, a maintained drop-in fork.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ git clone https://github.com/ShantnuS/AverageFrameColour.git
 
 Next a number of Python libraries need to be installed using pip:
 ```
-pip install pytube3
+pip install pytubefix
 pip install opencv-python
 pip install pillow 
 ```

--- a/average-colours.py
+++ b/average-colours.py
@@ -1,9 +1,9 @@
 #pip install list:
-# pytube
+# pytubefix
 # opencv-python
 # pillow
 
-from pytube import YouTube
+from pytubefix import YouTube
 import cv2
 import os 
 import shutil
@@ -51,8 +51,8 @@ def average_colours(video_url):
   #Download video
   print("downloading video...")
   video = YouTube(video_url)
-  stream = video.streams.filter(mime_type="video/mp4",res="360p").all()[0]
-  stream.download(download_folder, download_name)
+  stream = video.streams.filter(mime_type="video/mp4",res="360p").first()
+  stream.download(output_path=download_folder, filename=download_name+".mp4")
 
   print("averaging colours...")
   colour_list = get_colour_list(download_folder, download_name, frame_folder)


### PR DESCRIPTION
## Summary
- pytube3 is unmaintained and the script fails at startup with `HTTP Error 410: Gone` — YouTube removed the `get_video_info` endpoint it relies on
- Switch to [pytubefix](https://github.com/JuanBindez/pytubefix), a maintained drop-in fork: update the import, replace the removed `StreamQuery.all()` with `.first()`, and pass an explicit filename with extension to `Stream.download()`
- Add CLAUDE.md with repo guidance for Claude Code

## Test plan
- Ran `python average-colours.py` with a real YouTube URL: video downloads to `cache/test.mp4`, frames are extracted and averaged, and `output.png` is generated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)